### PR TITLE
Fixed `Duplicate identifier 'options'.`

### DIFF
--- a/src/Slider.d.ts
+++ b/src/Slider.d.ts
@@ -16,7 +16,6 @@ declare class Slider extends Vue {
   format?: any;
   classes?: object;
   showTooltip?: 'always'|'focus'|'drag';
-  options?: object;
   tooltipPosition?: null|'top'|'bottom'|'left'|'right';
   lazy?: boolean;
 


### PR DESCRIPTION
Fixed Typescript compile error: `Duplicate identifier 'options'`. 

Closes #40 