### PR TITLE
fix: avoid error when unloading component #34

### DIFF
--- a/src/composables/useSlider.js
+++ b/src/composables/useSlider.js
@@ -139,6 +139,9 @@ export default function useSlider (props, context, dependencies)
     slider.value.querySelectorAll('[data-handle]').forEach((handle) => {
       handle.onblur = () => {
         classList.value.focused.split(' ').forEach((c) => {
+          if (!slider.value) {
+            return // slider is being unloaded
+          }
           slider.value.classList.remove(c)
         })
       }


### PR DESCRIPTION
Really straightforward null-check for onblur handler.
I described how I was able to reproduce #34 and this should solve the problem, so people like me will stop seeing it in Bugsnag or Sentry.