### PR TITLE
feat: Add events 'start' and 'end'

### DIFF
--- a/src/Slider.vue
+++ b/src/Slider.vue
@@ -27,7 +27,7 @@
   export default {
     name: 'Slider',
     emits: [
-      'input', 'update:modelValue', 'update', 'change',
+      'input', 'update:modelValue', 'update', 'change', 'start', 'end',
     ],
     props: {
       ...valueProps,

--- a/src/composables/useSlider.js
+++ b/src/composables/useSlider.js
@@ -136,6 +136,16 @@ export default function useSlider (props, context, dependencies)
       }
     })
 
+    slider$.value.on('start', (val) => {
+      const sliderValue = getSliderValue()
+      context.emit('start', sliderValue)
+    })
+
+    slider$.value.on('end', (val) => {
+      const sliderValue = getSliderValue()
+      context.emit('end', sliderValue)
+    })
+
     slider.value.querySelectorAll('[data-handle]').forEach((handle) => {
       handle.onblur = () => {
         classList.value.focused.split(' ').forEach((c) => {


### PR DESCRIPTION
Hi,

it would be great, if support for the `start` and `end` event of the noUISlider could be added.

It would solve an issue I have. The slider is automatically updated every second (showing the playback progress in a music player). If the update happens while the slider handle is being dragged, the slider jumps to the position from the automatic update and interrupts the dragging (reported in this [issue](https://github.com/owntone/owntone-server/pull/1438)).

With the addition of the `start` and `end` events, I can solve this by only updating the slider in the background if it is not being dragged. 