### PR TITLE
fix(types): exports entities correctly from Slider.d.ts file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,2 @@
-import * as Slider from './Slider';
+export * from './Slider';
+export { default } from './Slider';


### PR DESCRIPTION
I've been using the fork that contains #90 and this PR for a long time now. But I wanted it to finally make it into upstream.